### PR TITLE
call reset_state

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -409,6 +409,7 @@ class Sam2Segmentation:
         if not keep_model_loaded:
             try:
                 model.to(offload_device)
+                model.reset_state(self.inference_state)
             except:
                 model.model.to(offload_device)
         


### PR DESCRIPTION
Multiple attempts on 4090 have shown that calling “reset_state“ can reduce GPU memory by over 1 GB. In situations where GPU resources are typically scarce, releasing GPU usage along with the model may be a better option